### PR TITLE
Fixed a bug causing event loop to not always start

### DIFF
--- a/src/Mpv.NET/MpvEventLoop.cs
+++ b/src/Mpv.NET/MpvEventLoop.cs
@@ -56,10 +56,9 @@ namespace Mpv.NET
 
 			DisposeEventLoopTask();
 
-			eventLoopTask = new Task(EventLoopThreadHandler);
+            IsRunning = true;
+            eventLoopTask = new Task(EventLoopThreadHandler);
 			eventLoopTask.Start();
-
-			IsRunning = true;
 		}
 
 		public void Stop()

--- a/src/Mpv.NET/MpvEventLoop.cs
+++ b/src/Mpv.NET/MpvEventLoop.cs
@@ -56,8 +56,9 @@ namespace Mpv.NET
 
 			DisposeEventLoopTask();
 
-            IsRunning = true;
-            eventLoopTask = new Task(EventLoopThreadHandler);
+			IsRunning = true;
+
+			eventLoopTask = new Task(EventLoopThreadHandler);
 			eventLoopTask.Start();
 		}
 


### PR DESCRIPTION
Event loop wouldn't always start because IsRunning is false when thread is started, and thus it exits right away if IsRunning isn't set to true before it starts looping. Resulting in loop working only 50% of times. You might want to fix the line spacing.