### PR TITLE
Update LoadFunction to new mpv_destroy argument

### DIFF
--- a/src/Mpv.NET/API/MpvFunctions.cs
+++ b/src/Mpv.NET/API/MpvFunctions.cs
@@ -70,7 +70,7 @@ namespace Mpv.NET.API
 			ClientName				= LoadFunction<MpvClientName>("mpv_client_name");
 			Create					= LoadFunction<MpvCreate>("mpv_create");
 			Initialise				= LoadFunction<MpvInitialise>("mpv_initialize");
-			DetachDestroy			= LoadFunction<MpvDetachDestroy>("mpv_detach_destroy");
+			DetachDestroy			= LoadFunction<MpvDetachDestroy>("mpv_destroy");
 			TerminateDestroy		= LoadFunction<MpvTerminateDestroy>("mpv_terminate_destroy");
 			CreateClient			= LoadFunction<MpvCreateClient>("mpv_create_client");
 			LoadConfigFile			= LoadFunction<MpvLoadConfigFile>("mpv_load_config_file");


### PR DESCRIPTION
As visible by the first image below, the function "mpv_detach_destroy" has been renamed quite a while ago.

![image](https://user-images.githubusercontent.com/83018798/170883217-247c805c-22f9-47bd-8ee3-198dec06c3f0.png)

When using Mpv.Net-lib- in Unity the following error occured when using newer versions of the libmpv file ("mpv-2.dll").

![image](https://user-images.githubusercontent.com/83018798/170883291-d09e8fd1-00f3-46e5-9392-6568e9a9ab76.png)

This pull request merely changes the string ("mpv_detach_destroy") of the requested function in the LoadFunction call with the current function name ("mpv_destroy").