### PR TITLE
Check for null reference and zero handle.

### DIFF
--- a/src/Mpv.NET/API/Mpv.cs
+++ b/src/Mpv.NET/API/Mpv.cs
@@ -437,7 +437,8 @@ namespace Mpv.NET.API
 				if (disposing && EventLoop is IDisposable disposableEventLoop)
 					disposableEventLoop.Dispose();
 
-				Functions.TerminateDestroy(Handle);
+				if (Handle != null && Handle != IntPtr.Zero)
+					Functions?.TerminateDestroy(Handle);
 
 				if (disposing && Functions is IDisposable disposableFunctions)
 					disposableFunctions.Dispose();


### PR DESCRIPTION
If the dll load fails we don't want an uncaught exception thrown due to null references.